### PR TITLE
Feature SmartZIP

### DIFF
--- a/widgets/online-express.php
+++ b/widgets/online-express.php
@@ -121,7 +121,21 @@ class Online_Express extends Widget_Base
 				'type' => Controls_Manager::TEXT,
 			]
 		);
-		
+
+		// SmartTRACK product.
+        $this->add_control(
+            'smartTrack_description',
+            [
+                'raw' => __(
+                    'If you want to enable SmartTrack, please provide your product credentials below.',
+                    'elementor-donations'
+                ),
+                'type' => Controls_Manager::RAW_HTML,
+                'content_classes' => 'elementor-descriptor',
+                'separator' => 'before',
+            ]
+        );
+
 		$this->add_control(
 			'smartTrackClient',
 			[
@@ -137,6 +151,44 @@ class Online_Express extends Widget_Base
 				'type' => Controls_Manager::TEXT,
 			]
 		);
+
+		// SmartZIP Product.
+        $this->add_control(
+            'smartZip_description',
+            [
+                'raw' => __(
+                    'If you want to enable SmartZIP, please provide your product credentials below.',
+                    'elementor-donations'
+                ),
+                'type' => Controls_Manager::RAW_HTML,
+                'content_classes' => 'elementor-descriptor',
+                'separator' => 'before',
+            ]
+        );
+
+        $this->add_control(
+            'smartZipClient',
+            [
+                'label' => __('SmartZIP Client', 'elementor-donations'),
+                'type' => Controls_Manager::TEXT,
+            ]
+        );
+
+        $this->add_control(
+            'smartZipId',
+            [
+                'label' => __('SmartZIP ID', 'elementor-donations'),
+                'type' => Controls_Manager::TEXT,
+            ]
+        );
+
+        $this->add_control(
+            'loqateApiKey',
+            [
+                'label' => __('Loqate API Key', 'elementor-donations'),
+                'type' => Controls_Manager::TEXT,
+            ]
+        );
 		
 		$this->end_controls_section();
 	}

--- a/widgets/online-express.php
+++ b/widgets/online-express.php
@@ -220,6 +220,12 @@ class Online_Express extends Widget_Base
 			echo '</script>';
 			echo '<script type="text/javascript">var SmartTRACKOLXSettings = {"redirecturl":"","NewSKU":true,"product":"SmartTRACKOLX","client":"' . $settings['smartTrackClient'] . '"}</script>';
 			echo '<script type="text/javascript" src="https://www.smartthing2.com/download/file.php?jsformat=1&olx=1&f=-js.html&c=' . $settings['smartTrackClient'] . '&k=' . $settings['smartTrackId'] . '"></script>';
+
+            // Enable SmartZIP if credentials are provided.
+            if ($settings['smartZipClient'] && $settings['smartZipId'] && $settings['loqateApiKey']) {
+                echo '<script type="text/javascript">var SmartZIPOLXSettings = {"pcaKey":"' . $settings['loqateApiKey'] . '","findAddressPrompt":"Find my address","manualPrompt":"Add address manually","product":"SmartZIPOLX","client":"' . $settings['smartZipClient'] . '"}</script>';
+                echo '<script type="text/javascript"src="https://www.smartthing2.com/download/file.php?jsformat=1&olx=1&f=-js.html&c=' . $settings['smartZipClient'] . '&k=' . $settings['smartZipId'] . '"></script>';
+            }
 		} else {
 			echo '<h4><em>Online Express - Form ID required.</em></h4>';
 		}

--- a/widgets/online-express.php
+++ b/widgets/online-express.php
@@ -127,7 +127,7 @@ class Online_Express extends Widget_Base
             'smartTrack_description',
             [
                 'raw' => __(
-                    'If you want to enable SmartTrack, please provide your product credentials below.',
+                    'If you want to enable SmartTRACK, please provide your product credentials below.',
                     'elementor-donations'
                 ),
                 'type' => Controls_Manager::RAW_HTML,


### PR DESCRIPTION
Allow users to add credentials for SmartZIP product and load the relevant snippet.

Load the snippet if all settings are provided.

Visual block separation of SmartTRACK, SmartZIP and main form ID settings.
Quick content for each block

![Screenshot 2020-02-11 at 16 55 06](https://user-images.githubusercontent.com/7203382/74259134-4ebb1680-4cef-11ea-909f-97f68007e23c.png)
